### PR TITLE
Fix comparison table anchor offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     :root{
       --bg:#ffffff;--fg:#0f172a;--muted:#475569;--brand:#0ea5e9;--accent:#22c55e;--line:#e2e8f0;--chip:#f1f5f9;
     }
-    html{scroll-behavior:smooth}
+    html{scroll-behavior:smooth;scroll-padding-top:72px}
     body{margin:0;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans JP","Hiragino Kaku Gothic ProN","Yu Gothic UI",sans-serif;line-height:1.75}
     a{color:var(--brand);text-decoration:none}
     a:hover{text-decoration:underline}


### PR DESCRIPTION
## Summary
- ensure in-page navigation leaves space for the comparison table so rows are no longer hidden behind the sticky header

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8d177bc4c83208d92f955faa519d4