### PR TITLE
Improve comparison table visibility under sticky header

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     :root{
       --bg:#ffffff;--fg:#0f172a;--muted:#475569;--brand:#0ea5e9;--accent:#22c55e;--line:#e2e8f0;--chip:#f1f5f9;
     }
-    html{scroll-behavior:smooth}
+    html{scroll-behavior:smooth;scroll-padding-top:96px}
     body{margin:0;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans JP","Hiragino Kaku Gothic ProN","Yu Gothic UI",sans-serif;line-height:1.75}
     a{color:var(--brand);text-decoration:none}
     a:hover{text-decoration:underline}
@@ -29,13 +29,14 @@
     h2{font-size:clamp(18px,2.2vw,24px);margin:32px 0 12px}
     .lead{color:var(--muted);font-size:16px}
     .toc{background:var(--chip);border:1px solid var(--line);border-radius:12px;padding:12px;margin:24px 0}
+    section[id]{scroll-margin-top:96px}
     .toc li{margin:6px 0}
 
     /* comparison table */
     .table-wrap{overflow-x:auto; overflow-y:visible; border:1px solid var(--line); border-radius:14px}
     table{width:100%;border-collapse:collapse;min-width:760px}
     th,td{padding:12px 10px;border-bottom:1px solid var(--line);vertical-align:top; word-break:break-word; overflow-wrap:anywhere}
-    th{background:#f8fafc;text-align:left;white-space:nowrap;position:sticky;top:56px;z-index:1}
+    th{background:#f8fafc;text-align:left;white-space:nowrap;position:sticky;top:72px;z-index:1}
     tbody tr:hover{background:#fafafa}
     .chip{display:inline-block;background:var(--chip);border:1px solid var(--line);padding:2px 8px;border-radius:999px;font-size:12px;margin-right:6px}
     .btns{display:flex;gap:8px;flex-wrap:wrap; min-width:200px}


### PR DESCRIPTION
## Summary
- increase the scroll offset so anchored sections, including the comparison table, clear the sticky site header
- adjust the table header's sticky offset so rows like the fan board entry remain fully visible when navigating

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8d177bc4c83208d92f955faa519d4