### PR TITLE
Refine article listings and unify action labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,9 @@
     .card .body{padding:14px}
     .card h3{margin:0 0 6px; font-size:18px}
     .card p{margin:0; color:var(--muted); font-size:14px}
+    .card .body ul{margin:8px 0 0; padding-left:18px; color:var(--muted); font-size:14px}
+    .card .body li{margin:4px 0}
+    .card .body li a{font-weight:700}
     .card .actions{display:flex; gap:8px; padding:12px 14px; margin-top:auto}
     .chip{display:inline-flex; align-items:center; gap:6px; border:1px solid var(--line); background:#fff; border-radius:999px; padding:6px 10px; font-weight:700}
 
@@ -107,10 +110,6 @@
           <h1>海を感じる、シンプルなサーフポータル</h1>
           <p>サーフボード選びの指針、遊べるミニゲーム、ボードを“盛る”ステッカー配布。<br>初心者にもわかりやすく、必要なものへすぐ届く。</p>
           <div class="cta">
-            <a class="btn btn--primary" href="./サーフボード選び.html" aria-label="サーフボード選びへ">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
-              サーフボード選び
-            </a>
             <a class="btn" href="#apps" aria-label="コンテンツ一覧へ">
               一覧を見る
             </a>
@@ -143,11 +142,14 @@
           <article class="card" role="listitem">
             <div class="thumb" aria-hidden="true"></div>
             <div class="body">
-              <h3>サーフボード選び【保存版】</h3>
-              <p>初心者の失敗を避けるためのサイズ・タイプの基礎と比較表。Amazon/Rakutenの検索リンクつき。</p>
+              <h3>記事</h3>
+              <p>サーフィンの基礎知識やハウツーをまとめた読み物コンテンツ。</p>
+              <ul>
+                <li><a href="./サーフボード選び.html" aria-label="サーフボード選び【保存版】の記事を開く">サーフボード選び【保存版】</a></li>
+              </ul>
             </div>
             <div class="actions">
-              <a class="chip" href="./サーフボード選び.html" aria-label="サーフボード選び 記事を開く">開く</a>
+              <a class="chip" href="./サーフボード選び.html" aria-label="サーフボード選び【保存版】の記事を開く">開く</a>
             </div>
           </article>
 
@@ -159,7 +161,7 @@
               <p>左右移動でコインを集めるシンプルゲーム。PC/スマホ対応、スコア保存に対応。</p>
             </div>
             <div class="actions">
-              <a class="chip" href="./game.html" aria-label="Surf Mini Game を開く">プレイ</a>
+              <a class="chip" href="./game.html" aria-label="Surf Mini Game を開く">開く</a>
             </div>
           </article>
 
@@ -171,7 +173,7 @@
               <p>ジョーク系ロゴ素材をSVG/PNGで配布。入稿のコツも掲載、印刷サービスへの導線つき。</p>
             </div>
             <div class="actions">
-              <a class="chip" href="./stickers.html" aria-label="ステッカー配布ページを開く">ダウンロード</a>
+              <a class="chip" href="./stickers.html" aria-label="ステッカー配布ページを開く">開く</a>
             </div>
           </article>
         </div>


### PR DESCRIPTION
## Summary
- restructure the first content card into an articles section that highlights the サーフボード選び【保存版】 entry
- remove the hero header shortcut link to the サーフボード選び page to keep navigation focused on the content list
- standardize content chip labels to 「開く」 for consistent calls to action

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc76fe9a08320961f81e28b316102