### PR TITLE
Add operator information page and update footer links

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>運営者情報｜Surf Nav</title>
+  <meta name="description" content="Surf Nav を運営する Surf Nav のプロフィールや連絡先、運営ポリシーをご案内します。" />
+  <link rel="canonical" href="https://example.com/about.html" />
+  <meta name="theme-color" content="#0ea5e9" />
+  <style>
+    :root {
+      --bg:#ffffff;
+      --fg:#0f172a;
+      --muted:#475569;
+      --line:#e2e8f0;
+      --brand:#0ea5e9;
+    }
+    body {
+      margin:0;
+      background:var(--bg);
+      color:var(--fg);
+      font-family:system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans JP", sans-serif;
+      line-height:1.8;
+    }
+    header, footer {
+      background:#f8fafc;
+      border-bottom:1px solid var(--line);
+      padding:16px 20px;
+    }
+    footer {
+      border-top:1px solid var(--line);
+      border-bottom:none;
+      font-size:14px;
+      color:var(--muted);
+      text-align:center;
+    }
+    main {
+      max-width:820px;
+      margin:0 auto;
+      padding:32px 20px 40px;
+    }
+    h1 {
+      font-size:clamp(24px,4vw,32px);
+      margin-bottom:16px;
+    }
+    h2 {
+      font-size:20px;
+      margin-top:32px;
+      margin-bottom:12px;
+    }
+    p {
+      margin:0 0 14px;
+    }
+    dl {
+      margin:0;
+      padding:0;
+    }
+    dt {
+      font-weight:600;
+      margin-top:18px;
+      color:var(--muted);
+    }
+    dd {
+      margin:6px 0 0 0;
+    }
+    ul {
+      margin:0 0 14px 20px;
+      padding:0;
+    }
+    a {
+      color:var(--brand);
+      text-decoration:none;
+    }
+    a:hover {
+      text-decoration:underline;
+    }
+    .foot-links {
+      display:flex;
+      justify-content:center;
+      gap:16px;
+      margin-top:8px;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <strong>Surf Nav</strong>
+  </header>
+
+  <main>
+    <h1>運営者情報</h1>
+    <p>Surf Nav（以下「当サイト」といいます）を運営する個人・組織についてご案内いたします。</p>
+
+    <dl>
+      <dt>サイト名</dt>
+      <dd>Surf Nav</dd>
+
+      <dt>運営者</dt>
+      <dd>Surf Nav</dd>
+
+      <dt>プロフィール</dt>
+      <dd>サーフィン歴20年以上。サーフボード診断や遊び心あるコンテンツを通じて、サーフィンの魅力を広めたいと思いサイトを運営しています。</dd>
+
+      <dt>連絡先</dt>
+      <dd><a href="mailto:surfnavmorning@gmail.com">surfnavmorning@gmail.com</a></dd>
+
+      <dt>公開日</dt>
+      <dd>2025年10月 サイト公開</dd>
+    </dl>
+
+    <h2>事業内容</h2>
+    <ul>
+      <li>サーフィン関連情報の提供</li>
+      <li>サーフボード比較記事の制作</li>
+      <li>関連商品の紹介（アフィリエイトリンクを含む）</li>
+    </ul>
+
+    <h2>運営ポリシー</h2>
+    <p>初心者から中級者まで、安心してサーフィンを楽しめるよう、役立つ情報をわかりやすく提供することを目的としています。</p>
+
+    <h2>免責事項</h2>
+    <p>当サイトで紹介する商品・サービスは当サイトが販売するものではなく、各販売者様との直接契約となります。当サイトは取引に関して責任を負いません。</p>
+  </main>
+
+  <footer>
+    <div>© <span id="year"></span> Surf Nav</div>
+    <div class="foot-links"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>

--- a/game.html
+++ b/game.html
@@ -52,7 +52,8 @@
     </section>
 
     <footer class="footer">
-      © <span id="year"></span> Surf Nav
+      <div>© <span id="year"></span> Surf Nav</div>
+      <div style="margin-top:6px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
     </footer>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
   <footer>
     <div class="wrap foot">
       <div>© <span id="year"></span> Surf Nav</div>
-      <div><a href="/policy.html">アフィリエイトポリシー</a></div>
+      <div><a href="/about.html">運営者情報</a> · <a href="/policy.html">アフィリエイトポリシー</a></div>
     </div>
   </footer>
 

--- a/policy.html
+++ b/policy.html
@@ -55,7 +55,8 @@
   </main>
 
   <footer>
-    © <span id="year"></span> Surf Nav
+    <div>© <span id="year"></span> Surf Nav</div>
+    <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 
   <script>

--- a/stickers.html
+++ b/stickers.html
@@ -65,7 +65,8 @@
   </main>
 
   <footer class="site-footer">
-    © <span id="year"></span> Surf Nav / Oka Surfer Items
+    <div>© <span id="year"></span> Surf Nav / Oka Surfer Items</div>
+    <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 
   <script src="./stickers.js" defer></script>


### PR DESCRIPTION
## Summary
- add a dedicated operator information page with contact, policy, and disclaimer details
- update footers across site pages to link to the operator information and affiliate policy

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dcd4c8cd008320b65022c9d51e8ab2