### PR TITLE
Add shared fixed navigation bar across Surf Nav pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Surf Nav を運営する Surf Nav のプロフィールや連絡先、運営ポリシーをご案内します。" />
   <link rel="canonical" href="https://example.com/about.html" />
   <meta name="theme-color" content="#0ea5e9" />
+  <link rel="stylesheet" href="./nav.css" />
   <style>
     :root {
       --bg:#ffffff;
@@ -21,11 +22,6 @@
       color:var(--fg);
       font-family:system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, "Noto Sans JP", sans-serif;
       line-height:1.8;
-    }
-    header, footer {
-      background:#f8fafc;
-      border-bottom:1px solid var(--line);
-      padding:16px 20px;
     }
     footer {
       border-top:1px solid var(--line);
@@ -83,8 +79,20 @@
   </style>
 </head>
 <body>
-  <header>
-    <strong>Surf Nav</strong>
+  <header class="global-bar">
+    <div class="global-bar__inner">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
+        <span>Surf Nav</span>
+      </a>
+      <nav class="global-bar__nav" aria-label="主要コンテンツ">
+        <a href="./index.html#apps">ホーム</a>
+        <a href="./サーフボード選び.html">サーフボード選び</a>
+        <a href="./game.html">ミニゲーム</a>
+        <a href="./stickers.html">ステッカー</a>
+        <a href="./about.html">運営者情報</a>
+      </nav>
+    </div>
   </header>
 
   <main>

--- a/game.css
+++ b/game.css
@@ -38,7 +38,7 @@ html, body {
 /* ===== レイアウト全体 =====
    1画面にピッタリ収めるため、縦フレックス＋キャンバスを 1fr で伸縮 */
 .wrap {
-  height: calc(100svh - var(--safe-top) - var(--safe-bottom));
+  height: calc(100svh - var(--safe-top) - var(--safe-bottom) - var(--global-bar-height));
   padding: calc(var(--pad) + var(--safe-top)) var(--pad) calc(var(--pad) + var(--safe-bottom));
   margin: 0 auto;
 
@@ -67,26 +67,6 @@ html, body {
   gap: 10px;
   flex-wrap: wrap;
   justify-content: flex-end;
-}
-.top-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  border: 1px solid rgba(255,255,255,.16);
-  background: rgba(45, 212, 191, 0.16);
-  color: var(--text);
-  font-weight: 600;
-  text-decoration: none;
-}
-.top-link::before {
-  content: "↑";
-  font-size: 12px;
-}
-.top-link:hover {
-  border-color: var(--accent);
-  background: rgba(45, 212, 191, 0.28);
 }
 .hud { display: flex; gap: 10px; font-weight: 700; color: var(--accent); }
 

--- a/game.html
+++ b/game.html
@@ -4,14 +4,30 @@
   <meta charset="UTF-8" />
   <title>Surf Mini Game</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./nav.css" />
   <link rel="stylesheet" href="./game.css" />
 </head>
 <body>
+  <header class="global-bar">
+    <div class="global-bar__inner">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
+        <span>Surf Nav</span>
+      </a>
+      <nav class="global-bar__nav" aria-label="主要コンテンツ">
+        <a href="./index.html#apps">ホーム</a>
+        <a href="./サーフボード選び.html">サーフボード選び</a>
+        <a href="./game.html">ミニゲーム</a>
+        <a href="./stickers.html">ステッカー</a>
+        <a href="./about.html">運営者情報</a>
+      </nav>
+    </div>
+  </header>
+
   <div class="wrap">
     <header class="topbar">
       <h1>🏄 Surf Mini Game</h1>
       <div class="topbar-right">
-        <a class="top-link" href="./index.html" aria-label="Surf Navのトップへ戻る">TOPに戻る</a>
         <div class="hud">
           <span id="score">Score: 0</span>
           <span id="best">Best: 0</span>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
   <meta property="og:url" content="https://example.com/" />
   <meta property="og:image" content="https://example.com/og/surf-home.jpg" />
   <meta name="theme-color" content="#0ea5e9" />
+  <link rel="stylesheet" href="./nav.css" />
   <style>
     :root{
       --bg:#ffffff; --fg:#0f172a; --muted:#475569; --line:#e2e8f0; --brand:#0ea5e9; --sea1:#0ea5e9; --sea2:#22d3ee; --sea3:#a7f3d0;
@@ -22,12 +23,7 @@
     a{color:var(--brand); text-decoration:none}
     a:hover{text-decoration:underline}
 
-    /* Header (Glass) */
-    header{position:sticky; top:0; z-index:50; backdrop-filter:saturate(140%) blur(8px); background:#ffffffb3; border-bottom:1px solid var(--line)}
     .wrap{max-width:1100px; margin:0 auto; padding:0 16px}
-    .nav{height:60px; display:flex; align-items:center; justify-content:space-between}
-    .logo{display:flex; align-items:center; gap:10px; font-weight:800; letter-spacing:0.2px}
-    .logo .wave{width:28px; height:28px}
 
     /* Hero */
     .hero{position:relative; padding:48px 0 24px}
@@ -89,15 +85,19 @@
   }
   </script>
 </head>
-<body>
-  <header>
-    <div class="wrap nav">
-      <div class="logo" aria-label="Surf Nav ホーム">
-        <svg class="wave" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
+<body id="top">
+  <header class="global-bar">
+    <div class="global-bar__inner">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
-      </div>
-      <nav>
-        <a href="#apps">コンテンツ</a>
+      </a>
+      <nav class="global-bar__nav" aria-label="主要コンテンツ">
+        <a href="./index.html#apps">ホーム</a>
+        <a href="./サーフボード選び.html">サーフボード選び</a>
+        <a href="./game.html">ミニゲーム</a>
+        <a href="./stickers.html">ステッカー</a>
+        <a href="./about.html">運営者情報</a>
       </nav>
     </div>
   </header>

--- a/nav.css
+++ b/nav.css
@@ -1,0 +1,75 @@
+:root {
+  --global-bar-height: 60px;
+}
+
+.global-bar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: saturate(140%) blur(8px);
+}
+
+.global-bar__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 16px;
+  min-height: var(--global-bar-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.global-bar__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 800;
+  color: #0f172a;
+  letter-spacing: 0.2px;
+  text-decoration: none;
+}
+
+.global-bar__brand span {
+  font-size: 18px;
+}
+
+.global-bar__brand svg {
+  width: 28px;
+  height: 28px;
+}
+
+.global-bar__nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.global-bar__nav a {
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 14px;
+  text-decoration: none;
+}
+
+.global-bar__nav a:hover,
+.global-bar__nav a:focus {
+  color: #0284c7;
+  outline: none;
+}
+
+@media (max-width: 640px) {
+  .global-bar__inner {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .global-bar__nav {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/policy.html
+++ b/policy.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Surf Nav のアフィリエイトポリシーをご案内します。" />
   <link rel="canonical" href="https://example.com/policy.html" />
   <meta name="theme-color" content="#0ea5e9" />
+  <link rel="stylesheet" href="./nav.css" />
   <style>
     body {
       margin:0; padding:0;
@@ -15,10 +16,13 @@
       color:#0f172a;
       line-height:1.8;
     }
-    header, footer {
-      border-bottom:1px solid #e2e8f0;
-      background:#f8fafc;
+    footer {
+      border-top:1px solid #e2e8f0;
+      font-size:14px;
+      color:#475569;
+      text-align:center;
       padding:14px 20px;
+      background:#f8fafc;
     }
     main {
       max-width:800px;
@@ -29,12 +33,23 @@
     h2 { font-size:18px; margin-top:24px; margin-bottom:12px }
     p { margin:0 0 12px }
     a { color:#0ea5e9; }
-    footer { border-top:1px solid #e2e8f0; font-size:14px; color:#475569; text-align:center; }
   </style>
 </head>
 <body>
-  <header>
-    <strong>Surf Nav</strong>
+  <header class="global-bar">
+    <div class="global-bar__inner">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
+        <span>Surf Nav</span>
+      </a>
+      <nav class="global-bar__nav" aria-label="主要コンテンツ">
+        <a href="./index.html#apps">ホーム</a>
+        <a href="./サーフボード選び.html">サーフボード選び</a>
+        <a href="./game.html">ミニゲーム</a>
+        <a href="./stickers.html">ステッカー</a>
+        <a href="./about.html">運営者情報</a>
+      </nav>
+    </div>
   </header>
 
   <main>

--- a/stickers.css
+++ b/stickers.css
@@ -17,9 +17,6 @@ html, body {
 .site-header { max-width: var(--max); margin: 24px auto 8px; padding: 0 16px; }
 .site-header__top { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
 .site-header h1 { font-size: clamp(20px, 3.5vw, 28px); margin: 0 0 6px; }
-.top-link { display: inline-flex; align-items: center; gap: 6px; padding: 6px 14px; border-radius: 999px; border: 1px solid rgba(96, 165, 250, .5); background: rgba(96, 165, 250, .16); color: var(--text); font-weight: 600; text-decoration: none; }
-.top-link::before { content: "↑"; font-size: 12px; }
-.top-link:hover { border-color: var(--accent2); background: rgba(96, 165, 250, .28); }
 .lead { color: var(--muted); margin: 0; line-height: 1.6; }
 
 /* container */

--- a/stickers.html
+++ b/stickers.html
@@ -4,13 +4,29 @@
   <meta charset="UTF-8" />
   <title>丘サーファーアイテム｜スポンサー風・丘サーファー風ステッカー配布</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="./nav.css" />
   <link rel="stylesheet" href="./stickers.css" />
 </head>
 <body>
+  <header class="global-bar">
+    <div class="global-bar__inner">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
+        <span>Surf Nav</span>
+      </a>
+      <nav class="global-bar__nav" aria-label="主要コンテンツ">
+        <a href="./index.html#apps">ホーム</a>
+        <a href="./サーフボード選び.html">サーフボード選び</a>
+        <a href="./game.html">ミニゲーム</a>
+        <a href="./stickers.html">ステッカー</a>
+        <a href="./about.html">運営者情報</a>
+      </nav>
+    </div>
+  </header>
+
   <header class="site-header">
     <div class="site-header__top">
       <h1>🏄 丘サーファーアイテム｜スポンサー風・丘サーファー風ステッカー</h1>
-      <a class="top-link" href="./index.html" aria-label="Surf Navのトップへ戻る">TOPに戻る</a>
     </div>
     <p class="lead">プロみたいにボードを“盛る”ジョーク系ステッカーに、<b>丘サーファー風イラスト</b>を追加。<br />SVG/PNGでダウンロードして、印刷サービスへ入稿してください。</p>
   </header>

--- a/サーフボード選び.html
+++ b/サーフボード選び.html
@@ -12,6 +12,7 @@
   <meta property="og:url" content="https://example.com/articles/beginner-surfboard-guide.html" />
   <meta property="og:image" content="https://example.com/og/surfboard-guide.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
+  <link rel="stylesheet" href="./nav.css" />
   <style>
     :root{
       --bg:#ffffff;--fg:#0f172a;--muted:#475569;--brand:#0ea5e9;--accent:#22c55e;--line:#e2e8f0;--chip:#f1f5f9;
@@ -20,14 +21,10 @@
     body{margin:0;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans JP","Hiragino Kaku Gothic ProN","Yu Gothic UI",sans-serif;line-height:1.75}
     a{color:var(--brand);text-decoration:none}
     a:hover{text-decoration:underline}
-    header{position:sticky;top:0;background:#fff8;backdrop-filter:saturate(140%) blur(8px);border-bottom:1px solid var(--line);z-index:50}
     .wrap{max-width:1080px;margin:0 auto;padding:0 16px}
-    .nav{display:flex;align-items:center;justify-content:space-between;height:56px}
-    .nav h1{font-size:18px;margin:0}
-    .nav nav{display:flex;align-items:center;gap:12px;flex-wrap:wrap;font-size:14px}
-    .nav nav span{color:var(--muted)}
-    .top-link{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:999px;border:1px solid var(--line);background:var(--brand);color:#fff;font-weight:600;font-size:13px}
-    .top-link:hover{background:#0284c7;border-color:#0284c7;color:#fff;text-decoration:none}
+    .page-links{display:flex;align-items:center;justify-content:flex-end;gap:12px;flex-wrap:wrap;font-size:14px;color:var(--muted);padding:12px 16px 0}
+    .page-links a{color:var(--muted);font-weight:600}
+    .page-links a:hover{color:var(--brand)}
     main{padding:24px 0}
     h1{font-size:clamp(24px,3vw,36px);line-height:1.3;margin:8px 0 16px}
     h2{font-size:clamp(18px,2.2vw,24px);margin:32px 0 12px}
@@ -113,17 +110,26 @@
   </script>
 </head>
 <body>
-  <header>
-    <div class="wrap nav">
-      <h1>Surf Lab</h1>
-      <nav>
-        <a href="#compare">比較表</a>
-        <span aria-hidden="true">/</span>
-        <a href="#faq">FAQ</a>
-        <a class="top-link" href="./index.html" aria-label="Surf Navのトップへ戻る">TOPに戻る</a>
+  <header class="global-bar">
+    <div class="global-bar__inner">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
+        <span>Surf Nav</span>
+      </a>
+      <nav class="global-bar__nav" aria-label="主要コンテンツ">
+        <a href="./index.html#apps">ホーム</a>
+        <a href="./サーフボード選び.html">サーフボード選び</a>
+        <a href="./game.html">ミニゲーム</a>
+        <a href="./stickers.html">ステッカー</a>
+        <a href="./about.html">運営者情報</a>
       </nav>
     </div>
   </header>
+
+  <nav class="page-links wrap" aria-label="ページ内リンク">
+    <a href="#compare">比較表</a>
+    <a href="#faq">FAQ</a>
+  </nav>
 
   <main class="wrap">
     <div class="breadcrumbs">ホーム › 記事 › 初心者向けサーフボードの選び方</div>


### PR DESCRIPTION
## Summary
- add a reusable navigation banner (nav.css) that stays fixed to the top of every Surf Nav page
- wire the new banner into each HTML page with links back to the home sections and key content areas
- adjust supporting styles so the game layout and sticker page spacing accommodate the shared header

## Testing
- Not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68dcd78b297083208ac0c3bcfc2e05c0