### PR TITLE
Remove Home breadcrumb from header band

### DIFF
--- a/about.html
+++ b/about.html
@@ -85,14 +85,17 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+        <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">運営者情報</li>
+      </ol>
+    </nav>
   </header>
 
   <main>

--- a/game.html
+++ b/game.html
@@ -14,14 +14,17 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+        <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">ミニゲーム</li>
+      </ol>
+    </nav>
   </header>
 
   <div class="wrap">

--- a/index.html
+++ b/index.html
@@ -92,13 +92,11 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+        <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
   </header>
 

--- a/nav.css
+++ b/nav.css
@@ -1,5 +1,5 @@
 :root {
-  --global-bar-height: 60px;
+  --global-bar-height: 94px;
 }
 
 .global-bar {
@@ -7,15 +7,15 @@
   top: 0;
   z-index: 100;
   border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: saturate(140%) blur(8px);
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: saturate(140%) blur(10px);
 }
 
 .global-bar__inner {
   max-width: 1100px;
   margin: 0 auto;
-  padding: 0 16px;
-  min-height: var(--global-bar-height);
+  padding: 12px 16px 0;
+  min-height: calc(var(--global-bar-height) - 36px);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -25,51 +25,132 @@
 .global-bar__brand {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-weight: 800;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(226, 245, 255, 0.9), rgba(207, 238, 255, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.2);
   color: #0f172a;
+  font-weight: 800;
   letter-spacing: 0.2px;
   text-decoration: none;
+}
+
+.global-bar__brand svg {
+  width: 28px;
+  height: 28px;
+  color: #0ea5e9;
 }
 
 .global-bar__brand span {
   font-size: 18px;
 }
 
-.global-bar__brand svg {
-  width: 28px;
-  height: 28px;
+.global-bar__menu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  border: none;
+  background: #0f172a;
+  color: #f8fafc;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
 }
 
-.global-bar__nav {
+.global-bar__menu:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.35);
+  outline-offset: 2px;
+}
+
+.global-bar__menu-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.global-bar__meta {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 8px 16px 14px;
+}
+
+.global-bar__crumbs {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 16px;
   flex-wrap: wrap;
+  gap: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #334155;
 }
 
-.global-bar__nav a {
-  color: #0f172a;
-  font-weight: 600;
-  font-size: 14px;
+.global-bar__crumbs li {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.global-bar__crumbs li + li::before {
+  content: "›";
+  color: rgba(51, 65, 85, 0.55);
+  font-size: 16px;
+}
+
+.global-bar__crumbs a {
+  color: #0284c7;
   text-decoration: none;
 }
 
-.global-bar__nav a:hover,
-.global-bar__nav a:focus {
-  color: #0284c7;
+.global-bar__crumbs a:hover,
+.global-bar__crumbs a:focus {
+  text-decoration: underline;
   outline: none;
+}
+
+.global-bar__crumbs [aria-current="page"] {
+  color: #0f172a;
 }
 
 @media (max-width: 640px) {
   .global-bar__inner {
-    flex-wrap: wrap;
-    justify-content: center;
+    padding-bottom: 4px;
+    gap: 12px;
   }
 
-  .global-bar__nav {
-    width: 100%;
-    justify-content: center;
+  .global-bar__brand {
+    padding: 8px 14px;
+    gap: 10px;
+  }
+
+  .global-bar__brand span {
+    font-size: 16px;
+  }
+
+  .global-bar__menu {
+    width: 46px;
+    height: 46px;
+    border-radius: 10px;
+  }
+
+  .global-bar__meta {
+    padding-bottom: 12px;
+  }
+
+  .global-bar__crumbs {
+    font-size: 14px;
+    gap: 8px;
+  }
+
+  .global-bar__crumbs li {
+    gap: 8px;
+  }
+
+  .global-bar__crumbs li + li::before {
+    font-size: 14px;
   }
 }

--- a/policy.html
+++ b/policy.html
@@ -42,14 +42,17 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+        <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">運営ポリシー</li>
+      </ol>
+    </nav>
   </header>
 
   <main>

--- a/stickers.html
+++ b/stickers.html
@@ -14,14 +14,17 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+        <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">ステッカー</li>
+      </ol>
+    </nav>
   </header>
 
   <header class="site-header">

--- a/サーフボード選び.html
+++ b/サーフボード選び.html
@@ -116,14 +116,18 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+        <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <path d="M4 6h16M4 12h16M4 18h16" />
+        </svg>
+      </button>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li><a href="./index.html#apps">記事</a></li>
+        <li aria-current="page">サーフボード選び【保存版】</li>
+      </ol>
+    </nav>
   </header>
 
   <nav class="page-links wrap" aria-label="ページ内リンク">


### PR DESCRIPTION
## Summary
- remove the Home breadcrumb from the sitewide header so the band no longer shows a redundant Home label
- adjust per-page breadcrumbs to start at the current section when a hierarchy is still helpful

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcdd5e700c832087ed8bf743e3b4be