### PR TITLE
Add interactive sitewide menu toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://example.com/about.html" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     :root {
       --bg:#ffffff;
@@ -85,14 +86,79 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <div class="global-bar__menu-container">
+        <button class="global-bar__menu" type="button" aria-label="コンテンツメニューを開く">
+          <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <div class="global-bar__panel">
+          <nav aria-label="コンテンツメニュー">
+            <ul class="global-bar__panel-list">
+              <li>
+                <a href="./index.html#apps">
+                  <span>01</span>
+                  <span class="global-bar__panel-text">
+                    <strong>トップ</strong>
+                    <small>おすすめコンテンツ一覧</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./サーフボード選び.html">
+                  <span>02</span>
+                  <span class="global-bar__panel-text">
+                    <strong>記事</strong>
+                    <small>サーフボード選びガイド</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./game.html">
+                  <span>03</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ミニゲーム</strong>
+                    <small>Surf Mini Game を遊ぶ</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./stickers.html">
+                  <span>04</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ステッカー</strong>
+                    <small>スポンサー風素材ダウンロード</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./about.html">
+                  <span>05</span>
+                  <span class="global-bar__panel-text">
+                    <strong>運営者情報</strong>
+                    <small>Surf Nav について</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./policy.html">
+                  <span>06</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ポリシー</strong>
+                    <small>アフィリエイト方針</small>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">運営者情報</li>
+      </ol>
+    </nav>
   </header>
 
   <main>
@@ -131,12 +197,8 @@
   </main>
 
   <footer>
-    <div>© <span id="year"></span> Surf Nav</div>
+    <div>© <span data-current-year></span> Surf Nav</div>
     <div class="foot-links"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
-
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/game.html
+++ b/game.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="./nav.css" />
   <link rel="stylesheet" href="./game.css" />
+  <script src="./nav.js" defer></script>
 </head>
 <body>
   <header class="global-bar">
@@ -14,14 +15,79 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <div class="global-bar__menu-container">
+        <button class="global-bar__menu" type="button" aria-label="コンテンツメニューを開く">
+          <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <div class="global-bar__panel">
+          <nav aria-label="コンテンツメニュー">
+            <ul class="global-bar__panel-list">
+              <li>
+                <a href="./index.html#apps">
+                  <span>01</span>
+                  <span class="global-bar__panel-text">
+                    <strong>トップ</strong>
+                    <small>おすすめコンテンツ一覧</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./サーフボード選び.html">
+                  <span>02</span>
+                  <span class="global-bar__panel-text">
+                    <strong>記事</strong>
+                    <small>サーフボード選びガイド</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./game.html">
+                  <span>03</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ミニゲーム</strong>
+                    <small>Surf Mini Game を遊ぶ</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./stickers.html">
+                  <span>04</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ステッカー</strong>
+                    <small>スポンサー風素材ダウンロード</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./about.html">
+                  <span>05</span>
+                  <span class="global-bar__panel-text">
+                    <strong>運営者情報</strong>
+                    <small>Surf Nav について</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./policy.html">
+                  <span>06</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ポリシー</strong>
+                    <small>アフィリエイト方針</small>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">ミニゲーム</li>
+      </ol>
+    </nav>
   </header>
 
   <div class="wrap">
@@ -68,7 +134,7 @@
     </section>
 
     <footer class="footer">
-      <div>© <span id="year"></span> Surf Nav</div>
+      <div>© <span data-current-year></span> Surf Nav</div>
       <div style="margin-top:6px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
     </footer>
   </div>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <meta property="og:image" content="https://example.com/og/surf-home.jpg" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     :root{
       --bg:#ffffff; --fg:#0f172a; --muted:#475569; --line:#e2e8f0; --brand:#0ea5e9; --sea1:#0ea5e9; --sea2:#22d3ee; --sea3:#a7f3d0;
@@ -92,13 +93,73 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <div class="global-bar__menu-container">
+        <button class="global-bar__menu" type="button" aria-label="コンテンツメニューを開く">
+          <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <div class="global-bar__panel">
+          <nav aria-label="コンテンツメニュー">
+            <ul class="global-bar__panel-list">
+              <li>
+                <a href="./index.html#apps">
+                  <span>01</span>
+                  <span class="global-bar__panel-text">
+                    <strong>トップ</strong>
+                    <small>おすすめコンテンツ一覧</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./サーフボード選び.html">
+                  <span>02</span>
+                  <span class="global-bar__panel-text">
+                    <strong>記事</strong>
+                    <small>サーフボード選びガイド</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./game.html">
+                  <span>03</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ミニゲーム</strong>
+                    <small>Surf Mini Game を遊ぶ</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./stickers.html">
+                  <span>04</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ステッカー</strong>
+                    <small>スポンサー風素材ダウンロード</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./about.html">
+                  <span>05</span>
+                  <span class="global-bar__panel-text">
+                    <strong>運営者情報</strong>
+                    <small>Surf Nav について</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./policy.html">
+                  <span>06</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ポリシー</strong>
+                    <small>アフィリエイト方針</small>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -191,13 +252,10 @@
 
   <footer>
     <div class="wrap foot">
-      <div>© <span id="year"></span> Surf Nav</div>
+      <div>© <span data-current-year></span> Surf Nav</div>
       <div><a href="/about.html">運営者情報</a> · <a href="/policy.html">アフィリエイトポリシー</a></div>
     </div>
   </footer>
 
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/nav.css
+++ b/nav.css
@@ -1,5 +1,5 @@
 :root {
-  --global-bar-height: 60px;
+  --global-bar-height: 94px;
 }
 
 .global-bar {
@@ -7,15 +7,15 @@
   top: 0;
   z-index: 100;
   border-bottom: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.92);
-  backdrop-filter: saturate(140%) blur(8px);
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: saturate(140%) blur(10px);
 }
 
 .global-bar__inner {
   max-width: 1100px;
   margin: 0 auto;
-  padding: 0 16px;
-  min-height: var(--global-bar-height);
+  padding: 12px 16px 0;
+  min-height: calc(var(--global-bar-height) - 36px);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -25,51 +25,241 @@
 .global-bar__brand {
   display: inline-flex;
   align-items: center;
-  gap: 10px;
-  font-weight: 800;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(226, 245, 255, 0.9), rgba(207, 238, 255, 0.92));
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.2);
   color: #0f172a;
+  font-weight: 800;
   letter-spacing: 0.2px;
   text-decoration: none;
+}
+
+.global-bar__brand svg {
+  width: 28px;
+  height: 28px;
+  color: #0ea5e9;
 }
 
 .global-bar__brand span {
   font-size: 18px;
 }
 
-.global-bar__brand svg {
-  width: 28px;
-  height: 28px;
-}
-
-.global-bar__nav {
+.global-bar__menu-container {
+  position: relative;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 16px;
-  flex-wrap: wrap;
 }
 
-.global-bar__nav a {
-  color: #0f172a;
+.global-bar__menu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  border-radius: 12px;
+  border: none;
+  background: #0f172a;
+  color: #f8fafc;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+}
+
+.global-bar__menu:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.35);
+  outline-offset: 2px;
+}
+
+.global-bar__menu-icon {
+  width: 24px;
+  height: 24px;
+}
+
+.global-bar__panel {
+  position: absolute;
+  top: calc(100% + 14px);
+  right: 0;
+  width: min(280px, 88vw);
+  padding: 18px 18px 16px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.97);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.22);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  display: none;
+}
+
+.global-bar__menu-container.is-open .global-bar__panel {
+  display: block;
+}
+
+.global-bar__panel::before {
+  content: "";
+  position: absolute;
+  top: -12px;
+  right: 18px;
+  width: 16px;
+  height: 16px;
+  background: inherit;
+  transform: rotate(45deg);
+  border-left: 1px solid rgba(148, 163, 184, 0.4);
+  border-top: 1px solid rgba(148, 163, 184, 0.4);
+}
+
+.global-bar__panel nav {
+  position: relative;
+  z-index: 1;
+}
+
+.global-bar__panel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.global-bar__panel a {
+  color: #f1f5f9;
+  text-decoration: none;
   font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.global-bar__panel a span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(14, 165, 233, 0.9);
   font-size: 14px;
+  font-weight: 700;
+}
+
+.global-bar__panel-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.global-bar__panel-text strong {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.global-bar__panel-text small {
+  display: block;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(148, 163, 184, 0.88);
+}
+
+.global-bar__panel a:hover,
+.global-bar__panel a:focus {
+  text-decoration: none;
+  color: #38bdf8;
+}
+
+.global-bar__meta {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 8px 16px 14px;
+}
+
+.global-bar__crumbs {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.global-bar__crumbs li {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.global-bar__crumbs li + li::before {
+  content: "›";
+  color: rgba(51, 65, 85, 0.55);
+  font-size: 16px;
+}
+
+.global-bar__crumbs a {
+  color: #0284c7;
   text-decoration: none;
 }
 
-.global-bar__nav a:hover,
-.global-bar__nav a:focus {
-  color: #0284c7;
+.global-bar__crumbs a:hover,
+.global-bar__crumbs a:focus {
+  text-decoration: underline;
   outline: none;
+}
+
+.global-bar__crumbs [aria-current="page"] {
+  color: #0f172a;
 }
 
 @media (max-width: 640px) {
   .global-bar__inner {
-    flex-wrap: wrap;
-    justify-content: center;
+    padding-bottom: 4px;
+    gap: 12px;
   }
 
-  .global-bar__nav {
-    width: 100%;
-    justify-content: center;
+  .global-bar__brand {
+    padding: 8px 14px;
+    gap: 10px;
+  }
+
+  .global-bar__brand span {
+    font-size: 16px;
+  }
+
+  .global-bar__menu {
+    width: 46px;
+    height: 46px;
+    border-radius: 10px;
+  }
+
+  .global-bar__menu {
+    box-shadow: 0 12px 26px rgba(15, 23, 42, 0.16);
+  }
+
+  .global-bar__meta {
+    padding-bottom: 12px;
+  }
+
+  .global-bar__crumbs {
+    font-size: 14px;
+    gap: 8px;
+  }
+
+  .global-bar__crumbs li {
+    gap: 8px;
+  }
+
+  .global-bar__crumbs li + li::before {
+    font-size: 14px;
+  }
+
+  .global-bar__panel {
+    right: -4px;
+    top: calc(100% + 10px);
+    padding: 16px 16px 14px;
+  }
+
+  .global-bar__panel::before {
+    right: 22px;
   }
 }

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,121 @@
+(function () {
+  const yearElements = document.querySelectorAll('[data-current-year]');
+  const currentYear = new Date().getFullYear();
+  yearElements.forEach((el) => {
+    el.textContent = currentYear;
+  });
+
+  const menuContainer = document.querySelector('.global-bar__menu-container');
+  if (!menuContainer) {
+    return;
+  }
+
+  const menuButton = menuContainer.querySelector('.global-bar__menu');
+  const menuPanel = menuContainer.querySelector('.global-bar__panel');
+
+  if (!menuButton || !menuPanel) {
+    return;
+  }
+
+  let lastFocusedElement = null;
+  const focusableSelectors = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const focusableContent = () => Array.from(menuPanel.querySelectorAll(focusableSelectors));
+
+  menuButton.setAttribute('aria-expanded', 'false');
+  menuPanel.setAttribute('hidden', '');
+
+  function openMenu() {
+    if (menuContainer.classList.contains('is-open')) {
+      return;
+    }
+
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    menuContainer.classList.add('is-open');
+    menuButton.setAttribute('aria-expanded', 'true');
+    menuPanel.removeAttribute('hidden');
+
+    const [firstFocusable] = focusableContent();
+    if (firstFocusable) {
+      window.requestAnimationFrame(() => firstFocusable.focus());
+    }
+
+    document.addEventListener('click', handleOutsideClick);
+    document.addEventListener('keydown', handleKeydown);
+  }
+
+  function closeMenu(restoreFocus = true) {
+    if (!menuContainer.classList.contains('is-open')) {
+      return;
+    }
+
+    menuContainer.classList.remove('is-open');
+    menuButton.setAttribute('aria-expanded', 'false');
+    menuPanel.setAttribute('hidden', '');
+
+    document.removeEventListener('click', handleOutsideClick);
+    document.removeEventListener('keydown', handleKeydown);
+
+    if (restoreFocus && lastFocusedElement) {
+      lastFocusedElement.focus();
+    } else if (restoreFocus) {
+      menuButton.focus();
+    }
+
+    lastFocusedElement = null;
+  }
+
+  function handleOutsideClick(event) {
+    if (!menuContainer.contains(event.target)) {
+      closeMenu(false);
+    }
+  }
+
+  function handleKeydown(event) {
+    if (event.key === 'Escape') {
+      closeMenu();
+      return;
+    }
+
+    if (event.key === 'Tab' && menuContainer.classList.contains('is-open')) {
+      const focusable = focusableContent();
+      if (!focusable.length) {
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    }
+  }
+
+  menuButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    if (menuContainer.classList.contains('is-open')) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+
+  menuButton.addEventListener('keydown', (event) => {
+    if ((event.key === 'Enter' || event.key === ' ') && !menuContainer.classList.contains('is-open')) {
+      event.preventDefault();
+      openMenu();
+    }
+  });
+
+  menuPanel.addEventListener('click', (event) => {
+    const link = event.target instanceof HTMLElement ? event.target.closest('a[href]') : null;
+    if (link) {
+      closeMenu(false);
+    }
+  });
+})();

--- a/policy.html
+++ b/policy.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://example.com/policy.html" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     body {
       margin:0; padding:0;
@@ -42,14 +43,79 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <div class="global-bar__menu-container">
+        <button class="global-bar__menu" type="button" aria-label="コンテンツメニューを開く">
+          <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <div class="global-bar__panel">
+          <nav aria-label="コンテンツメニュー">
+            <ul class="global-bar__panel-list">
+              <li>
+                <a href="./index.html#apps">
+                  <span>01</span>
+                  <span class="global-bar__panel-text">
+                    <strong>トップ</strong>
+                    <small>おすすめコンテンツ一覧</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./サーフボード選び.html">
+                  <span>02</span>
+                  <span class="global-bar__panel-text">
+                    <strong>記事</strong>
+                    <small>サーフボード選びガイド</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./game.html">
+                  <span>03</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ミニゲーム</strong>
+                    <small>Surf Mini Game を遊ぶ</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./stickers.html">
+                  <span>04</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ステッカー</strong>
+                    <small>スポンサー風素材ダウンロード</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./about.html">
+                  <span>05</span>
+                  <span class="global-bar__panel-text">
+                    <strong>運営者情報</strong>
+                    <small>Surf Nav について</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./policy.html">
+                  <span>06</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ポリシー</strong>
+                    <small>アフィリエイト方針</small>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">運営ポリシー</li>
+      </ol>
+    </nav>
   </header>
 
   <main>
@@ -70,12 +136,8 @@
   </main>
 
   <footer>
-    <div>© <span id="year"></span> Surf Nav</div>
+    <div>© <span data-current-year></span> Surf Nav</div>
     <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
-
-  <script>
-    document.getElementById('year').textContent = new Date().getFullYear();
-  </script>
 </body>
 </html>

--- a/stickers.html
+++ b/stickers.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="./nav.css" />
   <link rel="stylesheet" href="./stickers.css" />
+  <script src="./nav.js" defer></script>
 </head>
 <body>
   <header class="global-bar">
@@ -14,14 +15,79 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <div class="global-bar__menu-container">
+        <button class="global-bar__menu" type="button" aria-label="コンテンツメニューを開く">
+          <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <div class="global-bar__panel">
+          <nav aria-label="コンテンツメニュー">
+            <ul class="global-bar__panel-list">
+              <li>
+                <a href="./index.html#apps">
+                  <span>01</span>
+                  <span class="global-bar__panel-text">
+                    <strong>トップ</strong>
+                    <small>おすすめコンテンツ一覧</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./サーフボード選び.html">
+                  <span>02</span>
+                  <span class="global-bar__panel-text">
+                    <strong>記事</strong>
+                    <small>サーフボード選びガイド</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./game.html">
+                  <span>03</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ミニゲーム</strong>
+                    <small>Surf Mini Game を遊ぶ</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./stickers.html">
+                  <span>04</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ステッカー</strong>
+                    <small>スポンサー風素材ダウンロード</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./about.html">
+                  <span>05</span>
+                  <span class="global-bar__panel-text">
+                    <strong>運営者情報</strong>
+                    <small>Surf Nav について</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./policy.html">
+                  <span>06</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ポリシー</strong>
+                    <small>アフィリエイト方針</small>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li aria-current="page">ステッカー</li>
+      </ol>
+    </nav>
   </header>
 
   <header class="site-header">
@@ -81,7 +147,7 @@
   </main>
 
   <footer class="site-footer">
-    <div>© <span id="year"></span> Surf Nav / Oka Surfer Items</div>
+    <div>© <span data-current-year></span> Surf Nav / Oka Surfer Items</div>
     <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 

--- a/サーフボード選び.html
+++ b/サーフボード選び.html
@@ -13,6 +13,7 @@
   <meta property="og:image" content="https://example.com/og/surfboard-guide.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     :root{
       --bg:#ffffff;--fg:#0f172a;--muted:#475569;--brand:#0ea5e9;--accent:#22c55e;--line:#e2e8f0;--chip:#f1f5f9;
@@ -116,14 +117,80 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <nav class="global-bar__nav" aria-label="主要コンテンツ">
-        <a href="./index.html#apps">ホーム</a>
-        <a href="./サーフボード選び.html">サーフボード選び</a>
-        <a href="./game.html">ミニゲーム</a>
-        <a href="./stickers.html">ステッカー</a>
-        <a href="./about.html">運営者情報</a>
-      </nav>
+      <div class="global-bar__menu-container">
+        <button class="global-bar__menu" type="button" aria-label="コンテンツメニューを開く">
+          <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+        <div class="global-bar__panel">
+          <nav aria-label="コンテンツメニュー">
+            <ul class="global-bar__panel-list">
+              <li>
+                <a href="./index.html#apps">
+                  <span>01</span>
+                  <span class="global-bar__panel-text">
+                    <strong>トップ</strong>
+                    <small>おすすめコンテンツ一覧</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./サーフボード選び.html">
+                  <span>02</span>
+                  <span class="global-bar__panel-text">
+                    <strong>記事</strong>
+                    <small>サーフボード選びガイド</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./game.html">
+                  <span>03</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ミニゲーム</strong>
+                    <small>Surf Mini Game を遊ぶ</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./stickers.html">
+                  <span>04</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ステッカー</strong>
+                    <small>スポンサー風素材ダウンロード</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./about.html">
+                  <span>05</span>
+                  <span class="global-bar__panel-text">
+                    <strong>運営者情報</strong>
+                    <small>Surf Nav について</small>
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a href="./policy.html">
+                  <span>06</span>
+                  <span class="global-bar__panel-text">
+                    <strong>ポリシー</strong>
+                    <small>アフィリエイト方針</small>
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
     </div>
+    <nav class="global-bar__meta" aria-label="パンくずリスト">
+      <ol class="global-bar__crumbs">
+        <li><a href="./index.html#apps">記事</a></li>
+        <li aria-current="page">サーフボード選び【保存版】</li>
+      </ol>
+    </nav>
   </header>
 
   <nav class="page-links wrap" aria-label="ページ内リンク">
@@ -276,7 +343,7 @@
 
     <footer>
       <div class="foot">
-        <div>© <span id="year"></span> Surf Lab</div>
+        <div>© <span data-current-year></span> Surf Lab</div>
         <div><a href="/about.html">運営者情報</a> · <a href="/policy.html">アフィリエイトポリシー</a></div>
       </div>
     </footer>
@@ -367,8 +434,7 @@
       });
     }
 
-    // 年号とボタン生成を起動
-    document.getElementById('year').textContent = new Date().getFullYear();
+    // ボタン生成を起動
     mountButtons();
     syncMobileCards();
   </script>


### PR DESCRIPTION
## Summary
- add a shared menu panel to the header on every page so the top-right icon links to all Surf Nav content
- create a lightweight nav.js helper to manage the toggle behavior and shared footer year stamps
- refresh the navigation stylesheet for the new dropdown panel presentation and accessibility affordances

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcdd5e700c832087ed8bf743e3b4be