### PR TITLE
Add global menu overlay for site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://example.com/about.html" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     :root {
       --bg:#ffffff;
@@ -85,7 +86,7 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
           <path d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -137,6 +138,32 @@
     <div>© <span id="year"></span> Surf Nav</div>
     <div class="foot-links"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
+
+  <nav class="global-menu" id="global-menu" data-global-menu aria-hidden="true">
+    <div class="global-menu__backdrop" data-menu-dismiss aria-hidden="true"></div>
+    <div class="global-menu__panel" role="dialog" aria-modal="true" aria-labelledby="global-menu-title">
+      <div class="global-menu__header">
+        <h2 class="global-menu__title" id="global-menu-title">コンテンツ一覧</h2>
+        <button class="global-menu__close" type="button" aria-label="メニューを閉じる" data-menu-dismiss data-menu-initial>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        </button>
+      </div>
+      <ul class="global-menu__list">
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
+        <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
+        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
+      </ul>
+      <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>
+      <button class="global-menu__close" type="button" data-menu-dismiss>
+        メニューを閉じる
+      </button>
+    </div>
+  </nav>
 
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();

--- a/game.html
+++ b/game.html
@@ -5,6 +5,7 @@
   <title>Surf Mini Game</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <link rel="stylesheet" href="./game.css" />
 </head>
 <body>
@@ -14,7 +15,7 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
           <path d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -70,12 +71,38 @@
       </details>
     </section>
 
-    <footer class="footer">
-      <div>© <span id="year"></span> Surf Nav</div>
-      <div style="margin-top:6px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
-    </footer>
-  </div>
+  <footer class="footer">
+    <div>© <span id="year"></span> Surf Nav</div>
+    <div style="margin-top:6px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
+  </footer>
+</div>
 
-  <script src="./game.js" defer></script>
+<nav class="global-menu" id="global-menu" data-global-menu aria-hidden="true">
+    <div class="global-menu__backdrop" data-menu-dismiss aria-hidden="true"></div>
+  <div class="global-menu__panel" role="dialog" aria-modal="true" aria-labelledby="global-menu-title">
+    <div class="global-menu__header">
+      <h2 class="global-menu__title" id="global-menu-title">コンテンツ一覧</h2>
+      <button class="global-menu__close" type="button" aria-label="メニューを閉じる" data-menu-dismiss data-menu-initial>
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M6 6l12 12M18 6L6 18" />
+        </svg>
+      </button>
+    </div>
+    <ul class="global-menu__list">
+      <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+      <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+      <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
+      <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
+      <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+      <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
+    </ul>
+    <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>
+    <button class="global-menu__close" type="button" data-menu-dismiss>
+      メニューを閉じる
+    </button>
+  </div>
+</nav>
+
+<script src="./game.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <meta property="og:image" content="https://example.com/og/surf-home.jpg" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     :root{
       --bg:#ffffff; --fg:#0f172a; --muted:#475569; --line:#e2e8f0; --brand:#0ea5e9; --sea1:#0ea5e9; --sea2:#22d3ee; --sea3:#a7f3d0;
@@ -92,7 +93,7 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
           <path d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -193,6 +194,32 @@
       <div><a href="/about.html">運営者情報</a> · <a href="/policy.html">アフィリエイトポリシー</a></div>
     </div>
   </footer>
+
+  <nav class="global-menu" id="global-menu" data-global-menu aria-hidden="true">
+    <div class="global-menu__backdrop" data-menu-dismiss aria-hidden="true"></div>
+    <div class="global-menu__panel" role="dialog" aria-modal="true" aria-labelledby="global-menu-title">
+      <div class="global-menu__header">
+        <h2 class="global-menu__title" id="global-menu-title">コンテンツ一覧</h2>
+        <button class="global-menu__close" type="button" aria-label="メニューを閉じる" data-menu-dismiss data-menu-initial>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        </button>
+      </div>
+      <ul class="global-menu__list">
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
+        <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
+        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
+      </ul>
+      <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>
+      <button class="global-menu__close" type="button" data-menu-dismiss>
+        メニューを閉じる
+      </button>
+    </div>
+  </nav>
 
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();

--- a/nav.css
+++ b/nav.css
@@ -70,6 +70,124 @@
   height: 24px;
 }
 
+.global-menu {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 24px 16px;
+  background: transparent;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 200;
+  overflow-y: auto;
+}
+
+.global-menu[aria-hidden="true"] {
+  visibility: hidden;
+}
+
+.global-menu.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.global-menu__panel {
+  width: min(420px, 100%);
+  margin-top: clamp(20px, 6vh, 60px);
+  border-radius: 20px;
+  background: #ffffff;
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.25);
+  padding: 24px 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  position: relative;
+  z-index: 1;
+}
+
+.global-menu__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.25);
+  backdrop-filter: blur(6px);
+}
+
+.global-menu__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.global-menu__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 800;
+  color: #0f172a;
+}
+
+.global-menu__close {
+  border: none;
+  background: none;
+  padding: 8px;
+  border-radius: 10px;
+  color: #0f172a;
+  cursor: pointer;
+}
+
+.global-menu__close:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.35);
+  outline-offset: 2px;
+}
+
+.global-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.global-menu__item {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 16px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: linear-gradient(135deg, rgba(241, 245, 249, 0.6), rgba(248, 250, 252, 0.9));
+}
+
+.global-menu__item a {
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 17px;
+}
+
+.global-menu__item a:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.35);
+  outline-offset: 3px;
+}
+
+.global-menu__item p {
+  margin: 0;
+  color: #475569;
+  font-size: 14px;
+}
+
+.global-menu__footer {
+  font-size: 13px;
+  color: #64748b;
+}
+
+body.is-menu-open {
+  overflow: hidden;
+}
+
 .global-bar__meta {
   max-width: 1100px;
   margin: 0 auto;

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,119 @@
+(function () {
+  const menu = document.querySelector('[data-global-menu]');
+  const menuButton = document.querySelector('.global-bar__menu');
+  if (!menu || !menuButton) {
+    return;
+  }
+
+  const focusableSelectors = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])'
+  ];
+
+  let lastFocusedElement = null;
+
+  function getFocusableElements() {
+    return menu.querySelectorAll(focusableSelectors.join(','));
+  }
+
+  function openMenu() {
+    if (menu.classList.contains('is-open')) {
+      return;
+    }
+
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    menu.classList.add('is-open');
+    menu.setAttribute('aria-hidden', 'false');
+    menuButton.setAttribute('aria-expanded', 'true');
+    document.body.classList.add('is-menu-open');
+
+    const focusTarget = menu.querySelector('[data-menu-initial]');
+    const focusable = focusTarget || getFocusableElements()[0];
+    if (focusable instanceof HTMLElement) {
+      focusable.focus();
+    }
+  }
+
+  function closeMenu() {
+    if (!menu.classList.contains('is-open')) {
+      return;
+    }
+
+    menu.classList.remove('is-open');
+    menu.setAttribute('aria-hidden', 'true');
+    menuButton.setAttribute('aria-expanded', 'false');
+    document.body.classList.remove('is-menu-open');
+
+    if (lastFocusedElement instanceof HTMLElement) {
+      lastFocusedElement.focus();
+    } else {
+      menuButton.focus();
+    }
+  }
+
+  function handleToggle() {
+    if (menu.classList.contains('is-open')) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  }
+
+  menuButton.addEventListener('click', handleToggle);
+
+  menu.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    if (target.hasAttribute('data-menu-dismiss')) {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+
+    const link = target.closest('a');
+    if (link && menu.contains(link)) {
+      closeMenu();
+    }
+  });
+
+  menu.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeMenu();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const focusable = Array.from(getFocusableElements());
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const currentIndex = focusable.indexOf(document.activeElement);
+      let nextIndex = currentIndex;
+
+      if (event.shiftKey) {
+        nextIndex = currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1;
+      } else {
+        nextIndex = currentIndex === focusable.length - 1 ? 0 : currentIndex + 1;
+      }
+
+      focusable[nextIndex].focus();
+      event.preventDefault();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && menu.classList.contains('is-open')) {
+      event.preventDefault();
+      closeMenu();
+    }
+  });
+})();

--- a/policy.html
+++ b/policy.html
@@ -8,6 +8,7 @@
   <link rel="canonical" href="https://example.com/policy.html" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     body {
       margin:0; padding:0;
@@ -42,7 +43,7 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
           <path d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -76,6 +77,32 @@
     <div>© <span id="year"></span> Surf Nav</div>
     <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
+
+  <nav class="global-menu" id="global-menu" data-global-menu aria-hidden="true">
+    <div class="global-menu__backdrop" data-menu-dismiss aria-hidden="true"></div>
+    <div class="global-menu__panel" role="dialog" aria-modal="true" aria-labelledby="global-menu-title">
+      <div class="global-menu__header">
+        <h2 class="global-menu__title" id="global-menu-title">コンテンツ一覧</h2>
+        <button class="global-menu__close" type="button" aria-label="メニューを閉じる" data-menu-dismiss data-menu-initial>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        </button>
+      </div>
+      <ul class="global-menu__list">
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
+        <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
+        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
+      </ul>
+      <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>
+      <button class="global-menu__close" type="button" data-menu-dismiss>
+        メニューを閉じる
+      </button>
+    </div>
+  </nav>
 
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();

--- a/stickers.html
+++ b/stickers.html
@@ -5,6 +5,7 @@
   <title>丘サーファーアイテム｜スポンサー風・丘サーファー風ステッカー配布</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <link rel="stylesheet" href="./stickers.css" />
 </head>
 <body>
@@ -14,7 +15,7 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
           <path d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -87,6 +88,32 @@
     <div>© <span id="year"></span> Surf Nav / Oka Surfer Items</div>
     <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
+
+  <nav class="global-menu" id="global-menu" data-global-menu aria-hidden="true">
+    <div class="global-menu__backdrop" data-menu-dismiss aria-hidden="true"></div>
+    <div class="global-menu__panel" role="dialog" aria-modal="true" aria-labelledby="global-menu-title">
+      <div class="global-menu__header">
+        <h2 class="global-menu__title" id="global-menu-title">コンテンツ一覧</h2>
+        <button class="global-menu__close" type="button" aria-label="メニューを閉じる" data-menu-dismiss data-menu-initial>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        </button>
+      </div>
+      <ul class="global-menu__list">
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
+        <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
+        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
+      </ul>
+      <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>
+      <button class="global-menu__close" type="button" data-menu-dismiss>
+        メニューを閉じる
+      </button>
+    </div>
+  </nav>
 
   <script src="./stickers.js" defer></script>
 </body>

--- a/サーフボード選び.html
+++ b/サーフボード選び.html
@@ -13,6 +13,7 @@
   <meta property="og:image" content="https://example.com/og/surfboard-guide.jpg" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="stylesheet" href="./nav.css" />
+  <script src="./nav.js" defer></script>
   <style>
     :root{
       --bg:#ffffff;--fg:#0f172a;--muted:#475569;--brand:#0ea5e9;--accent:#22c55e;--line:#e2e8f0;--chip:#f1f5f9;
@@ -116,7 +117,7 @@
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
         <span>Surf Nav</span>
       </a>
-      <button class="global-bar__menu" type="button" aria-label="メニューを開く">
+      <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
           <path d="M4 6h16M4 12h16M4 18h16" />
         </svg>
@@ -376,5 +377,31 @@
     mountButtons();
     syncMobileCards();
   </script>
+
+  <nav class="global-menu" id="global-menu" data-global-menu aria-hidden="true">
+    <div class="global-menu__backdrop" data-menu-dismiss aria-hidden="true"></div>
+    <div class="global-menu__panel" role="dialog" aria-modal="true" aria-labelledby="global-menu-title">
+      <div class="global-menu__header">
+        <h2 class="global-menu__title" id="global-menu-title">コンテンツ一覧</h2>
+        <button class="global-menu__close" type="button" aria-label="メニューを閉じる" data-menu-dismiss data-menu-initial>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        </button>
+      </div>
+      <ul class="global-menu__list">
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
+        <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
+        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
+      </ul>
+      <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>
+      <button class="global-menu__close" type="button" data-menu-dismiss>
+        メニューを閉じる
+      </button>
+    </div>
+  </nav>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared global menu overlay component with consistent markup on each page
- style the overlay and wire up focus management and dismissal logic in a new nav.js helper

## Testing
- Manual verification via `python -m http.server 8000` and Playwright screenshot

------
https://chatgpt.com/codex/tasks/task_e_68dcf44d578883209d9470a3ead4aae6