### PR TITLE
Add wave logo sticker lineup

### DIFF
--- a/stickers.js
+++ b/stickers.js
@@ -742,6 +742,173 @@
       })
     });
 
+    // 添付ロゴ（丘サーファー風ラインナップ追加）
+    list.push({
+      id:"logo-sand-wave-lines", title:"WAVE LINES｜サンドエンブレム",
+      tags:["logo","wave","minimal"], badge:["線画","サンド","横長"],
+      editable:[], defaultFields:{},
+      svg: ({w=880,h=420}={}) => withFrame({
+        w,h, stroke:"#fcd34d", strokeW:10, bg:"#f5e7d1",
+        body:(x,y,W,H)=>{
+          const sw = Math.min(W,H)*0.06;
+          const startX = x + W*0.08;
+          const endX = x + W*0.92;
+          const wave = ratio => {
+            const midX = startX + (endX-startX)/2;
+            return `M ${startX} ${y+H*ratio} C ${startX+W*0.16} ${y+H*(ratio-0.18)}, ${midX-W*0.06} ${y+H*(ratio+0.18)}, ${midX} ${y+H*ratio} S ${endX-W*0.16} ${y+H*(ratio-0.18)}, ${endX} ${y+H*ratio}`;
+          };
+          return `
+            <g stroke="#111827" stroke-width="${sw}" fill="none" stroke-linecap="round" stroke-linejoin="round">
+              ${[0.36,0.50,0.64].map(wave).join("\n              ")}
+            </g>
+          `;
+        }
+      })
+    });
+
+    list.push({
+      id:"logo-bowl-wave", title:"SURF BOWL｜波のうつわロゴ",
+      tags:["logo","wave","emblem"], badge:["カットライン","ブルー","ラウンド"],
+      editable:[], defaultFields:{},
+      svg: ({w=720,h=540}={}) => withFrame({
+        w,h, stroke:"#fbbf24", strokeW:10, bg:"#f5efe0",
+        body:(x,y,W,H)=>{
+          const cx = x + W/2;
+          const cy = y + H*0.56;
+          const r = Math.min(W,H)*0.34;
+          const innerR = r*0.92;
+          const bowl = `M ${cx-r} ${cy} A ${r} ${r} 0 0 1 ${cx+r} ${cy} L ${cx+r} ${cy+r*0.55} Q ${cx} ${cy+r*0.85} ${cx-r} ${cy+r*0.55} Z`;
+          const wave1 = `M ${cx-r*0.82} ${cy-r*0.15} C ${cx-r*0.50} ${cy-r*0.55}, ${cx-r*0.10} ${cy-r*0.10}, ${cx} ${cy-r*0.28} S ${cx+r*0.60} ${cy-r*0.60}, ${cx+r*0.80} ${cy-r*0.12}`;
+          const wave2 = `M ${cx-r*0.86} ${cy+r*0.08} C ${cx-r*0.30} ${cy+r*0.36}, ${cx-r*0.06} ${cy+r*0.06}, ${cx+r*0.20} ${cy+r*0.26}`;
+          return `
+            <g fill="none">
+              <path d="${bowl}" fill="#e0c79f" stroke="#e0c79f" stroke-width="${r*0.05}"/>
+              <path d="M ${cx-innerR} ${cy} A ${innerR} ${innerR} 0 0 1 ${cx+innerR} ${cy}" stroke="#1c7dd3" stroke-width="${r*0.16}" fill="none" stroke-linecap="round"/>
+              <g stroke-linecap="round" stroke-linejoin="round" stroke="#1c7dd3" stroke-width="${r*0.10}">
+                <path d="${wave1}" fill="none"/>
+                <path d="${wave2}" fill="none"/>
+              </g>
+            </g>
+          `;
+        }
+      })
+    });
+
+    list.push({
+      id:"logo-sunrise-wave", title:"SUNRISE SURF｜サンライズロゴ",
+      tags:["logo","wave","sun"], badge:["サンセット","ストライプ","円形"],
+      editable:[], defaultFields:{},
+      svg: ({w=720,h=540}={}) => withFrame({
+        w,h, stroke:"#facc15", strokeW:10, bg:"#f5efe0",
+        body:(x,y,W,H)=>{
+          const cx = x + W/2;
+          const cy = y + H/2;
+          const r = Math.min(W,H)*0.38;
+          const stripes = [0.25,0.42,0.59].map((_,i)=>{
+            const offset = -r*0.10 + i*r*0.18;
+            const yPos = cy + offset;
+            return `<path d="M ${cx-r*0.90} ${yPos} C ${cx-r*0.40} ${yPos-r*0.24}, ${cx+r*0.40} ${yPos+r*0.24}, ${cx+r*0.90} ${yPos}" fill="none" stroke="#0ea5e9" stroke-width="${r*0.16}" stroke-linecap="round"/>`;
+          }).join("\n");
+          return `
+            <g>
+              <circle cx="${cx}" cy="${cy+r*0.05}" r="${r}" fill="#f3d7a3"/>
+              <circle cx="${cx}" cy="${cy-r*0.35}" r="${r*0.42}" fill="#facc15"/>
+              ${stripes}
+            </g>
+          `;
+        }
+      })
+    });
+
+    list.push({
+      id:"logo-surfboard-crest", title:"SURFBOARD CREST｜エンブレム",
+      tags:["logo","wave","crest"], badge:["サーフボード","ティール","シンボル"],
+      editable:[], defaultFields:{},
+      svg: ({w=780,h=540}={}) => withFrame({
+        w,h, stroke:"#22d3ee", strokeW:10, bg:"#e5f4f8",
+        body:(x,y,W,H)=>{
+          const cx = x + W/2;
+          const cy = y + H/2;
+          const r = Math.min(W,H)*0.40;
+          const board = `M ${cx} ${cy-r*0.95} C ${cx+r*0.18} ${cy-r*0.30}, ${cx+r*0.22} ${cy+r*0.45}, ${cx} ${cy+r*0.95} C ${cx-r*0.22} ${cy+r*0.45}, ${cx-r*0.18} ${cy-r*0.30}, ${cx} ${cy-r*0.95} Z`;
+          const waveA = `M ${cx-r*0.90} ${cy+r*0.30} C ${cx-r*0.45} ${cy+r*0.05}, ${cx-r*0.05} ${cy+r*0.45}, ${cx+r*0.35} ${cy+r*0.20}`;
+          const waveB = `M ${cx-r*0.40} ${cy+r*0.05} C ${cx+r*0.05} ${cy+r*0.35}, ${cx+r*0.45} ${cy-r*0.05}, ${cx+r*0.82} ${cy+r*0.18}`;
+          return `
+            <defs><linearGradient id="crestGrad" x1="0" y1="1" x2="1" y2="0"><stop offset="0" stop-color="#0ea5e9"/><stop offset="1" stop-color="#14b8a6"/></linearGradient></defs>
+            <circle cx="${cx}" cy="${cy}" r="${r}" fill="#0f172a" opacity="0.85"/>
+            <path d="${board}" fill="url(#crestGrad)" stroke="#0f172a" stroke-width="${r*0.05}" stroke-linejoin="round"/>
+            <g stroke-linecap="round" stroke-linejoin="round">
+              <path d="${waveA}" stroke="#0ea5e9" stroke-width="${r*0.10}" fill="none"/>
+              <path d="${waveB}" stroke="#1dd6c5" stroke-width="${r*0.08}" fill="none"/>
+            </g>
+          `;
+        }
+      })
+    });
+
+    list.push({
+      id:"logo-surf-eye", title:"SURF EYE｜サークルロゴ",
+      tags:["logo","wave","minimal"], badge:["アイコン","ツートン","丸型"],
+      editable:[], defaultFields:{},
+      svg: ({w=640,h=640}={}) => withFrame({
+        w,h, stroke:"#0ea5e9", strokeW:12, bg:"#0f172a",
+        body:(x,y,W,H)=>{
+          const cx = x + W/2;
+          const cy = y + H/2;
+          const r = Math.min(W,H)*0.38;
+          return `
+            <circle cx="${cx}" cy="${cy}" r="${r}" fill="#0f172a"/>
+            <path d="M ${cx-r*0.90} ${cy} A ${r*0.90} ${r*0.90} 0 0 1 ${cx+r*0.90} ${cy}" stroke="#f97316" stroke-width="${r*0.22}" fill="none" stroke-linecap="round"/>
+            <path d="M ${cx-r*0.72} ${cy+r*0.05} A ${r*0.72} ${r*0.72} 0 0 0 ${cx+r*0.20} ${cy+r*0.45}" fill="#14b8a6"/>
+            <circle cx="${cx+r*0.12}" cy="${cy+r*0.10}" r="${r*0.32}" fill="#0f172a"/>
+            <circle cx="${cx+r*0.10}" cy="${cy+r*0.10}" r="${r*0.18}" fill="#14b8a6"/>
+          `;
+        }
+      })
+    });
+
+    list.push({
+      id:"logo-wave-sun-emblem", title:"SUN WAVE｜サークルエンブレム",
+      tags:["logo","wave","sun"], badge:["夕焼け","しぶき","ラウンド"],
+      editable:[], defaultFields:{},
+      svg: ({w=720,h=540}={}) => withFrame({
+        w,h, stroke:"#fb923c", strokeW:10, bg:"#f5efe0",
+        body:(x,y,W,H)=>{
+          const cx = x + W/2;
+          const cy = y + H/2;
+          const r = Math.min(W,H)*0.42;
+          return `
+            <circle cx="${cx}" cy="${cy}" r="${r}" fill="#facc15"/>
+            <path d="M ${cx-r*0.96} ${cy+r*0.10} C ${cx-r*0.40} ${cy-r*0.45}, ${cx+r*0.10} ${cy-r*0.10}, ${cx+r*0.70} ${cy-r*0.35} Q ${cx+r*0.40} ${cy+r*0.36} ${cx+r*0.96} ${cy+r*0.12} Z" fill="#0f172a" opacity="0.10"/>
+            <path d="M ${cx-r*0.90} ${cy+r*0.05} C ${cx-r*0.30} ${cy-r*0.35}, ${cx+r*0.05} ${cy+r*0.05}, ${cx+r*0.60} ${cy-r*0.20} Q ${cx+r*0.10} ${cy+r*0.26} ${cx+r*0.90} ${cy+r*0.08} Z" fill="#0ea5e9"/>
+            <path d="M ${cx-r*0.20} ${cy+r*0.04} C ${cx-r*0.05} ${cy-r*0.18}, ${cx+r*0.18} ${cy-r*0.02}, ${cx+r*0.36} ${cy-r*0.22} Q ${cx+r*0.30} ${cy+r*0.10} ${cx+r*0.02} ${cy+r*0.22} Z" fill="#38bdf8"/>
+            <path d="M ${cx-r*0.78} ${cy+r*0.32} C ${cx-r*0.36} ${cy+r*0.06}, ${cx} ${cy+r*0.42}, ${cx+r*0.44} ${cy+r*0.16} Q ${cx+r*0.22} ${cy+r*0.44} ${cx-r*0.10} ${cy+r*0.48} Z" fill="#0f172a"/>
+          `;
+        }
+      })
+    });
+
+    list.push({
+      id:"logo-wave-letter-c", title:"C WAVE｜タイポロゴ",
+      tags:["logo","wave","letter"], badge:["シンボル","シンプル","グリーン"],
+      editable:[], defaultFields:{},
+      svg: ({w=720,h=540}={}) => withFrame({
+        w,h, stroke:"#10b981", strokeW:10, bg:"#f5efe0",
+        body:(x,y,W,H)=>{
+          const cx = x + W/2;
+          const cy = y + H/2;
+          const r = Math.min(W,H)*0.38;
+          const arc = `M ${cx+r*0.70} ${cy-r*0.10} C ${cx+r*0.20} ${cy-r*0.54}, ${cx-r*0.56} ${cy-r*0.32}, ${cx-r*0.62} ${cy} C ${cx-r*0.56} ${cy+r*0.32}, ${cx+r*0.20} ${cy+r*0.54}, ${cx+r*0.70} ${cy+r*0.10}`;
+          const wave = `M ${cx-r*0.28} ${cy+r*0.06} C ${cx-r*0.02} ${cy-r*0.14}, ${cx+r*0.22} ${cy+r*0.08}, ${cx+r*0.46} ${cy-r*0.08}`;
+          return `
+            <path d="${arc}" stroke="#0f172a" stroke-width="${r*0.26}" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="${arc}" stroke="#14b8a6" stroke-width="${r*0.18}" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="${wave}" stroke="#0ea5e9" stroke-width="${r*0.12}" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+          `;
+        }
+      })
+    });
+
     return list;
   }
 


### PR DESCRIPTION
## Summary
- add seven new wave-inspired sticker logos matching the provided assets
- render each logo with custom SVG definitions and categorize them for search and badges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9946efe483208c7ef347b3da7c61