### PR TITLE
Add numbering to sticker cards

### DIFF
--- a/stickers.css
+++ b/stickers.css
@@ -47,6 +47,16 @@ html, body {
 /* meta */
 .meta { padding: 10px 12px; border-top: 1px solid var(--line); display: grid; gap: 8px; }
 .meta h3{ margin: 0; font-size: 15px; }
+.card__heading{ display:flex; align-items:center; gap:8px; }
+.card__heading h3{ flex:1; }
+.card__index{
+  display:inline-flex; align-items:center; justify-content:center;
+  min-width:56px; padding:2px 10px; border-radius:999px;
+  background:#0f1a2e; color:var(--accent2);
+  font-size:12px; font-weight:700; letter-spacing:0.08em;
+  line-height:1; text-transform:uppercase;
+  border:1px solid var(--line);
+}
 .badges{ display: flex; gap: 6px; flex-wrap: wrap; }
 .badge{ font-size: 11px; color: var(--muted); background: #0f1a2e; border: 1px solid var(--line); padding: 2px 8px; border-radius: 999px; }
 

--- a/stickers.js
+++ b/stickers.js
@@ -90,6 +90,9 @@
 
   // ========= デザイン定義 =========
   const designs = buildDesigns();
+  designs.forEach((d, idx) => {
+    d.no = idx + 1;
+  });
 
   // ========= 一覧UI・検索・タグ =========
   const grid = $("#grid");
@@ -116,11 +119,15 @@
       .forEach(d => {
         const card = document.createElement("article");
         card.className = "card";
+        const numLabel = String(d.no ?? 0).padStart(2, "0");
         const svgSmall = d.svg({w:900, h:Math.round(900*0.6), fields:d.defaultFields});
         card.innerHTML = `
           <div class="preview" aria-label="${escapeHtml(d.title)} のプレビュー">${svgSmall}</div>
           <div class="meta">
-            <h3>${escapeHtml(d.title)}</h3>
+            <div class="card__heading">
+              <span class="card__index" aria-label="ステッカー番号 ${numLabel}">No.${numLabel}</span>
+              <h3>${escapeHtml(d.title)}</h3>
+            </div>
             <div class="badges">${d.badge.map(b => `<span class="badge">${escapeHtml(b)}</span>`).join("")}</div>
             <div class="actions">
               <button class="btn" data-act="customize" data-id="${d.id}">カスタマイズ</button>


### PR DESCRIPTION
## Summary
- assign sequential numbers to each sticker definition and display them in the card header for easier management
- style the new number badges to match the existing card design

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9ee856cc8320ad0057a8fa6d184f