### PR TITLE
Adjust sticker previews to fit frames

### DIFF
--- a/stickers.css
+++ b/stickers.css
@@ -40,9 +40,20 @@ html, body {
 /* preview（はみ出し防止の決定版） */
 .preview{
   background: repeating-conic-gradient(#1e293b 0% 25%, #0f172a 0% 50%) 50%/20px 20px;
-  aspect-ratio: 3 / 2; display: grid; place-items: center; overflow: hidden;
+  aspect-ratio: 3 / 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(12px, 2.5vw, 20px);
+  overflow: hidden;
 }
-.preview svg{ width: 100%; max-width: 100%; height: auto; display: block; }
+.preview svg{
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  max-height: 100%;
+  display: block;
+}
 
 /* meta */
 .meta { padding: 10px 12px; border-top: 1px solid var(--line); display: grid; gap: 8px; }

--- a/stickers.js
+++ b/stickers.js
@@ -110,6 +110,28 @@
   });
   $("#q").addEventListener("input", render);
 
+  function applyPreviewAspect(previewEl){
+    if (!previewEl) return;
+    const svgEl = previewEl.querySelector('svg');
+    if (!svgEl) return;
+    const vbAttr = svgEl.getAttribute('viewBox');
+    if (vbAttr){
+      const parts = vbAttr.trim().split(/\s+/);
+      if (parts.length >= 4){
+        const w = parseFloat(parts[parts.length - 2]);
+        const h = parseFloat(parts[parts.length - 1]);
+        if (w > 0 && h > 0){
+          previewEl.style.aspectRatio = `${w} / ${h}`;
+          return;
+        }
+      }
+    }
+    const vb = svgEl.viewBox?.baseVal;
+    if (vb?.width && vb?.height){
+      previewEl.style.aspectRatio = `${vb.width} / ${vb.height}`;
+    }
+  }
+
   function render(){
     grid.innerHTML = "";
     const q = $("#q").value.trim().toLowerCase();
@@ -138,6 +160,7 @@
           </div>
         `;
         grid.appendChild(card);
+        applyPreviewAspect(card.querySelector('.preview'));
       });
     $$(".actions .btn", grid).forEach(btn => btn.addEventListener("click", onAction));
   }
@@ -209,6 +232,7 @@
     currentFields = collectFieldsFromForm();
     const svg = currentDesign.svg({fields:currentFields});
     modalPreview.innerHTML = svg;
+    applyPreviewAspect(modalPreview);
   }
 
   $("#apply").addEventListener("click", updateModalPreview);


### PR DESCRIPTION
## Summary
- update sticker preview styling so artwork is centered with consistent padding
- detect each SVG viewBox to set per-design aspect ratios in cards and the modal preview

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddb4043e4c8320816e3a3f3b918b70