### PR TITLE
Fix navigation links to surfboard and beginner gear pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -152,7 +152,8 @@
       </div>
       <ul class="global-menu__list">
         <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
-        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
         <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>

--- a/beginner-gear.html
+++ b/beginner-gear.html
@@ -124,7 +124,7 @@
       <aside class="aside">
         <strong>関連記事</strong>
         <ul style="margin:8px 0 0">
-          <li><a href="./サーフボード選び.html">初心者向けサーフボードの選び方と比較表</a></li>
+          <li><a href="./surfboard-guide.html">初心者向けサーフボードの選び方と比較表</a></li>
           <li><a href="./stickers.html">スポンサー風・丘サーファー風ステッカー</a></li>
         </ul>
       </aside>

--- a/game.html
+++ b/game.html
@@ -90,7 +90,8 @@
     </div>
     <ul class="global-menu__list">
       <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
-      <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+      <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+      <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
       <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
       <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
       <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>

--- a/index.html
+++ b/index.html
@@ -142,8 +142,8 @@
               <h3>記事</h3>
               <p>サーフィンの基礎知識やhow toをまとめた読み物コンテンツ。</p>
               <ul>
-                <li><a href="./surfboard-guide.html" aria-label="サーフボード選び【保存版】の記事を開く">サーフボード選び【保存版】</a></li>
-                <li><a href="./beginner-gear.html" aria-label="初心者が揃えるべき道具一式の記事を開く">初心者が揃えるべき道具一式</a></li>
+                <li><a href="surfboard-guide.html" aria-label="サーフボード選び【保存版】の記事を開く">サーフボード選び【保存版】</a></li>
+                <li><a href="beginner-gear.html" aria-label="初心者が揃えるべき道具一式の記事を開く">初心者が揃えるべき道具一式</a></li>
               </ul>
             </div>
           </article>
@@ -204,8 +204,8 @@
       </div>
       <ul class="global-menu__list">
         <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
-        <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
-        <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
+        <li class="global-menu__item"><a href="surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
         <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>

--- a/policy.html
+++ b/policy.html
@@ -91,7 +91,8 @@
       </div>
       <ul class="global-menu__list">
         <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
-        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
         <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>

--- a/stickers.html
+++ b/stickers.html
@@ -104,7 +104,8 @@
       </div>
       <ul class="global-menu__list">
         <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
-        <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
+        <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
         <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>

--- a/surfboard-guide.html
+++ b/surfboard-guide.html
@@ -124,7 +124,7 @@
       <aside class="aside">
         <strong>関連記事</strong>
         <ul style="margin:8px 0 0">
-          <li><a href="./サーフボード選び.html">初心者向けサーフボードの選び方と比較表</a></li>
+          <li><a href="./surfboard-guide.html">初心者向けサーフボードの選び方と比較表</a></li>
           <li><a href="./stickers.html">スポンサー風・丘サーファー風ステッカー</a></li>
         </ul>
       </aside>


### PR DESCRIPTION
## Summary
- update the global menus on static pages so the surfboard guide and beginner gear entries link to the correct HTML files
- fix related article links to reference the surfboard guide file name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21a9d63808320b898c7b4b1611403