### PR TITLE
Rename Surf Nav branding to SloSea

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>運営者情報｜Surf Nav</title>
-  <meta name="description" content="Surf Nav を運営する Surf Nav のプロフィールや連絡先、運営ポリシーをご案内します。" />
+  <title>運営者情報｜SloSea</title>
+  <meta name="description" content="SloSea を運営する SloSea のプロフィールや連絡先、運営ポリシーをご案内します。" />
   <link rel="canonical" href="https://example.com/about.html" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
@@ -82,9 +82,9 @@
 <body>
   <header class="global-bar">
     <div class="global-bar__inner">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
@@ -101,14 +101,14 @@
 
   <main>
     <h1>運営者情報</h1>
-    <p>Surf Nav（以下「当サイト」といいます）を運営する個人・組織についてご案内いたします。</p>
+    <p>SloSea（以下「当サイト」といいます）を運営する個人・組織についてご案内いたします。</p>
 
     <dl>
       <dt>サイト名</dt>
-      <dd>Surf Nav</dd>
+      <dd>SloSea</dd>
 
       <dt>運営者</dt>
-      <dd>Surf Nav</dd>
+      <dd>SloSea</dd>
 
       <dt>プロフィール</dt>
       <dd>サーフィン歴20年以上。サーフボード診断や遊び心あるコンテンツを通じて、サーフィンの魅力を広めたいと思いサイトを運営しています。</dd>
@@ -135,7 +135,7 @@
   </main>
 
   <footer>
-    <div>© <span id="year"></span> Surf Nav</div>
+    <div>© <span id="year"></span> SloSea</div>
     <div class="foot-links"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 
@@ -151,12 +151,12 @@
         </button>
       </div>
       <ul class="global-menu__list">
-        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>SloSea の最新コンテンツまとめ。</p></li>
         <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
         <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
-        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./about.html">SloSea について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
         <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
       </ul>
       <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>

--- a/beginner-gear.html
+++ b/beginner-gear.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>初心者が揃えるべき道具一式｜Surf Nav</title>
+  <title>初心者が揃えるべき道具一式｜SloSea</title>
   <meta name="description" content="サーフィン初心者がまず揃えるべき道具一式を厳選。必須・あると便利に分け、Amazon・楽天の検索ボタンで素早く比較購入できます。" />
   <link rel="stylesheet" href="./nav.css" />
   <script src="./nav.js" defer></script>
@@ -60,9 +60,9 @@
   <!-- グローバルバー（既存サイトに合わせた簡易版） -->
   <header class="global-bar">
     <div class="global-bar__inner wrap" style="display:flex;align-items:center;justify-content:space-between;padding:10px 0">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る" style="display:flex;align-items:center;gap:8px;font-weight:700;color:inherit">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る" style="display:flex;align-items:center;gap:8px;font-weight:700;color:inherit">
         <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <nav class="global-bar__meta" aria-label="パンくずリスト">
         <ol class="global-bar__crumbs" style="list-style:none;display:flex;gap:8px;margin:0;padding:0;font-size:13px;color:var(--muted)">
@@ -132,7 +132,7 @@
 
     <footer>
       <div class="foot">
-        <div>© <span id="year"></span> Surf Nav</div>
+        <div>© <span id="year"></span> SloSea</div>
         <div><a href="./about.html">運営者情報</a> · <a href="./policy.html">アフィリエイトポリシー</a></div>
       </div>
     </footer>

--- a/game.html
+++ b/game.html
@@ -11,9 +11,9 @@
 <body>
   <header class="global-bar">
     <div class="global-bar__inner">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
@@ -72,7 +72,7 @@
     </section>
 
   <footer class="footer">
-    <div>© <span id="year"></span> Surf Nav</div>
+    <div>© <span id="year"></span> SloSea</div>
     <div style="margin-top:6px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 </div>
@@ -89,12 +89,12 @@
       </button>
     </div>
     <ul class="global-menu__list">
-      <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+      <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>SloSea の最新コンテンツまとめ。</p></li>
       <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
       <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
       <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
       <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
-      <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+      <li class="global-menu__item"><a href="./about.html">SloSea について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
       <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
     </ul>
     <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>

--- a/index.html
+++ b/index.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Surf Nav｜サーフコンテンツのポータル</title>
+  <title>SloSea｜サーフコンテンツのポータル</title>
   <meta name="description" content="サーフィン関連記事、ミニゲーム、ステッカー配布など、サーファー向けの楽しい・役立つコンテンツをひとまとめ。初心者にもやさしい入口です。" />
   <link rel="canonical" href="https://example.com/" />
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Surf Nav｜サーフコンテンツのポータル" />
+  <meta property="og:title" content="SloSea｜サーフコンテンツのポータル" />
   <meta property="og:description" content="サーフィン関連記事、ミニゲーム、ステッカー配布など、サーファー向けの楽しい・役立つコンテンツをひとまとめ。" />
   <meta property="og:url" content="https://example.com/" />
   <meta property="og:image" content="https://example.com/og/surf-home.jpg" />
@@ -77,7 +77,7 @@
   {
     "@context":"https://schema.org",
     "@type":"WebSite",
-    "name":"Surf Nav",
+    "name":"SloSea",
     "url":"https://example.com/",
     "potentialAction":{
       "@type":"SearchAction",
@@ -90,9 +90,9 @@
 <body id="top">
   <header class="global-bar">
     <div class="global-bar__inner">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
@@ -179,14 +179,14 @@
     <section class="section" aria-labelledby="about-title">
       <div class="wrap">
         <h2 id="about-title">このサイトについて</h2>
-        <p class="wrap" style="color:var(--muted)">Surf Nav は、軽快でシンプルな静的サイトとして構築しています。コンテンツは初心者向けに厳選し、更新が少なくても価値が維持されるよう設計しています。アフィリエイトリンクを含む場合があります。</p>
+        <p class="wrap" style="color:var(--muted)">SloSea は、軽快でシンプルな静的サイトとして構築しています。コンテンツは初心者向けに厳選し、更新が少なくても価値が維持されるよう設計しています。アフィリエイトリンクを含む場合があります。</p>
       </div>
     </section>
   </main>
 
   <footer>
     <div class="wrap foot">
-      <div>© <span id="year"></span> Surf Nav</div>
+      <div>© <span id="year"></span> SloSea</div>
       <div><a href="/about.html">運営者情報</a> · <a href="/policy.html">アフィリエイトポリシー</a></div>
     </div>
   </footer>
@@ -203,12 +203,12 @@
         </button>
       </div>
       <ul class="global-menu__list">
-        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>SloSea の最新コンテンツまとめ。</p></li>
         <li class="global-menu__item"><a href="surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
         <li class="global-menu__item"><a href="beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
-        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./about.html">SloSea について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
         <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
       </ul>
       <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>

--- a/policy.html
+++ b/policy.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>アフィリエイトポリシー｜Surf Nav</title>
-  <meta name="description" content="Surf Nav のアフィリエイトポリシーをご案内します。" />
+  <title>アフィリエイトポリシー｜SloSea</title>
+  <meta name="description" content="SloSea のアフィリエイトポリシーをご案内します。" />
   <link rel="canonical" href="https://example.com/policy.html" />
   <meta name="theme-color" content="#0ea5e9" />
   <link rel="stylesheet" href="./nav.css" />
@@ -39,9 +39,9 @@
 <body>
   <header class="global-bar">
     <div class="global-bar__inner">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
@@ -58,7 +58,7 @@
 
   <main>
     <h1>アフィリエイトポリシー</h1>
-    <p>Surf Nav（以下「当サイト」といいます）では、アフィリエイトプログラムを利用して商品・サービスをご紹介しています。これは、当サイトが直接販売を行うものではありません。</p>
+    <p>SloSea（以下「当サイト」といいます）では、アフィリエイトプログラムを利用して商品・サービスをご紹介しています。これは、当サイトが直接販売を行うものではありません。</p>
 
     <h2>アフィリエイトリンクについて</h2>
     <p>当サイト内のリンクを経由して商品・サービスを購入いただくと、紹介料が当サイトに還元される場合があります。購入者様に追加の費用が発生することはありません。</p>
@@ -74,7 +74,7 @@
   </main>
 
   <footer>
-    <div>© <span id="year"></span> Surf Nav</div>
+    <div>© <span id="year"></span> SloSea</div>
     <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 
@@ -90,12 +90,12 @@
         </button>
       </div>
       <ul class="global-menu__list">
-        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>SloSea の最新コンテンツまとめ。</p></li>
         <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
         <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
-        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./about.html">SloSea について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
         <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
       </ul>
       <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>

--- a/stickers.html
+++ b/stickers.html
@@ -11,9 +11,9 @@
 <body>
   <header class="global-bar">
     <div class="global-bar__inner">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
@@ -87,7 +87,7 @@
   </main>
 
   <footer class="site-footer">
-    <div>© <span id="year"></span> Surf Nav / Oka Surfer Items</div>
+    <div>© <span id="year"></span> SloSea / Oka Surfer Items</div>
     <div style="margin-top:8px"><a href="./about.html">運営者情報</a>・<a href="./policy.html">アフィリエイトポリシー</a></div>
   </footer>
 
@@ -103,12 +103,12 @@
         </button>
       </div>
       <ul class="global-menu__list">
-        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>SloSea の最新コンテンツまとめ。</p></li>
         <li class="global-menu__item"><a href="./surfboard-guide.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
         <li class="global-menu__item"><a href="./beginner-gear.html">初心者が揃えるべき道具一式</a><p>着替えポンチョ・バケツなど必携小物まとめ。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
-        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./about.html">SloSea について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
         <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
       </ul>
       <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>

--- a/surfboard-guide.html
+++ b/surfboard-guide.html
@@ -76,9 +76,9 @@
 <body>
   <header class="global-bar">
     <div class="global-bar__inner">
-      <a class="global-bar__brand" href="./index.html#top" aria-label="Surf Nav のトップへ戻る">
+      <a class="global-bar__brand" href="./index.html#top" aria-label="SloSea のトップへ戻る">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 16c4 0 4-8 8-8s4 8 8 8 4-8 8-8"/></svg>
-        <span>Surf Nav</span>
+        <span>SloSea</span>
       </a>
       <button class="global-bar__menu" type="button" aria-label="メニューを開く" aria-expanded="false" aria-controls="global-menu">
         <svg class="global-bar__menu-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
@@ -345,11 +345,11 @@
         </button>
       </div>
       <ul class="global-menu__list">
-        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>Surf Nav の最新コンテンツまとめ。</p></li>
+        <li class="global-menu__item"><a href="./index.html#apps">ホーム / コンテンツ一覧</a><p>SloSea の最新コンテンツまとめ。</p></li>
         <li class="global-menu__item"><a href="./サーフボード選び.html">サーフボード選び【保存版】</a><p>目的に合わせたボードの選び方ガイド。</p></li>
         <li class="global-menu__item"><a href="./game.html">Surf Mini Game</a><p>波を避けてコインを集めるカジュアルゲーム。</p></li>
         <li class="global-menu__item"><a href="./stickers.html">サーフステッカー配布</a><p>ボードやSNSで使えるデジタルステッカー。</p></li>
-        <li class="global-menu__item"><a href="./about.html">Surf Nav について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
+        <li class="global-menu__item"><a href="./about.html">SloSea について</a><p>サイトのコンセプトや制作背景を紹介。</p></li>
         <li class="global-menu__item"><a href="./policy.html">プライバシーポリシー</a><p>利用者のみなさまに安心して使っていただくために。</p></li>
       </ul>
       <p class="global-menu__footer">ご希望のコンテンツを選択してください。</p>


### PR DESCRIPTION
## Summary
- replace the Surf Nav brand name with SloSea across all static pages
- update page titles, metadata, headings, footer credits, and navigation labels to reflect the new name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e47c5482e483208b9246c8bf8c394d