### PR TITLE
Update surfboard guide footer branding

### DIFF
--- a/surfboard-guide.html
+++ b/surfboard-guide.html
@@ -238,7 +238,7 @@
 
     <footer>
       <div class="foot">
-        <div>© <span id="year"></span> Surf Lab</div>
+        <div>© <span id="year"></span> SloSea</div>
         <div><a href="/about.html">運営者情報</a> · <a href="/policy.html">アフィリエイトポリシー</a></div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary
- replace the footer branding text from Surf Lab to SloSea on the surfboard guide page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e483ed2ba0832080e1893997dd1adf